### PR TITLE
Feature/multiple networks

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,8 +1,11 @@
 BACKEND_URL=https://dev.peeersyst.com
 MINIMUM_TRANSACTION_AMOUNT=61
 EXPLORER_LINK=https://explorer.nervos.org/aggron/
-CKB_URL=https://ckb-node-test-1.peersyst.com/rpc
-INDEXER_URL=https://ckb-node-test-1.peersyst.com/indexer
+CKB_TESTNET_URL=http://ckb-node-test-1.peersyst.com/rpc
+INDEXER_TESTNET_URL=http://ckb-node-test-1.peersyst.com/indexer
+CKB_MAINNET_URL=https://ckb-node-mainnet.peersyst.com/rpc
+INDEXER_MAINNET_URL=https://ckb-node-mainnet.peersyst.com/indexer
 MINIMUM_DAO_DEPOSIT=102
 MAX_NUMBER_OF_DECIMALS=6
 FAUCET_URL=https://faucet.nervos.org/
+ENABLE_MAINNET=false

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 MINIMUM_TRANSACTION_AMOUNT=61
 EXPLORER_LINK=https://explorer.nervos.org/
-CKB_URL=http://78.46.174.87:8114/rpc
-INDEXER_URL=http://78.46.174.87:8114/indexer
+CKB_TESTNET_URL=http://ckb-node-test-1.peersyst.com/rpc
+INDEXER_TESTNET_URL=http://ckb-node-test-1.peersyst.com/indexer
+CKB_MAINNET_URL=https://ckb-node-mainnet.peersyst.com/rpc
+INDEXER_MAINNET_URL=https://ckb-node-mainnet.peersyst.com/indexer
 MINIMUM_DAO_DEPOSIT=102
 MAX_NUMBER_OF_DECIMALS=6
 FAUCET_URL=https://faucet.nervos.org/
+ENABLE_MAINNET=false

--- a/eas.json
+++ b/eas.json
@@ -9,11 +9,14 @@
                 "BUILD_NUMBER": "__BUILD_NUMBER__",
                 "MINIMUM_TRANSACTION_AMOUNT": "61",
                 "EXPLORER_LINK": "https://explorer.nervos.org/aggron/",
-                "CKB_URL": "https://ckb-node-test-1.peersyst.com/rpc",
-                "INDEXER_URL": "https://ckb-node-test-1.peersyst.com/indexer",
+                "CKB_TESTNET_URL": "https://ckb-node-test-1.peersyst.com/rpc",
+                "INDEXER_TESTNET_URL": "https://ckb-node-test-1.peersyst.com/indexer",
+                "CKB_MAINNET_URL": "https://ckb-node-mainnet.peersyst.com/rpc",
+                "INDEXER_MAINNET_URL": "https://ckb-node-mainnet.peersyst.com/indexer",
                 "MINIMUM_DAO_DEPOSIT": "102",
                 "MAX_NUMBER_OF_DECIMALS": "6",
-                "FAUCET_URL": "https://faucet.nervos.org/"
+                "FAUCET_URL": "https://faucet.nervos.org/",
+                "ENABLE_MAINNET": false
             },
             "android": {
                 "buildType": "apk"

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,8 +3,11 @@ declare module "@env" {
     export const MINIMUM_TRANSACTION_AMOUNT: string;
     export const MINIMUM_DAO_DEPOSIT: string;
     export const EXPLORER_LINK: string;
-    export const CKB_URL: string;
-    export const INDEXER_URL: string;
+    export const CKB_TESTNET_URL: string;
+    export const INDEXER_TESTNET_URL: string;
+    export const CKB_MAINNET_URL: string;
+    export const INDEXER_MAINNET_URL: string;
     export const MAX_NUMBER_OF_DECIMALS: string;
     export const FAUCET_URL: string;
+    export const ENABLE_MAINNET: string;
 }

--- a/src/module/common/query/useLoad.ts
+++ b/src/module/common/query/useLoad.ts
@@ -31,14 +31,14 @@ export function useLoad(): boolean {
                 setSettingsState(settings);
 
                 for (let i = 0; i < wallets.length; i += 1) {
-                    const { initialState, mnemonic } = wallets.find((w) => w.index === i)!;
-                    await createServiceInstance(i, mnemonic, initialState);
+                    const { testnet, mainnet, mnemonic } = wallets.find((w) => w.index === i)!;
+                    await createServiceInstance(i, mnemonic, testnet?.initialState, mainnet?.initialState);
                 }
 
                 //Use another thread
                 setTimeout(async () => {
                     for (let i = 0; i < serviceInstancesMap.size; i += 1) {
-                        await serviceInstancesMap.get(i)?.synchronize();
+                        await serviceInstancesMap.get(i)?.[settings.network]?.synchronize();
                     }
                 });
             }

--- a/src/module/common/service/CkbSdkService.ts
+++ b/src/module/common/service/CkbSdkService.ts
@@ -12,8 +12,8 @@ import {
     Transaction,
 } from "ckb-peersyst-sdk";
 import { tokenAmountZeroBalanceList, tokensList, UknownToken } from "module/token/mock/token";
-import { DepositInDAOParams, FullTransaction, SendTransactionParams, WithdrawOrUnlockParams } from "./CkbSdkService.types";
-import { CKB_URL, INDEXER_URL } from "@env";
+import { Chain, DepositInDAOParams, FullTransaction, SendTransactionParams, WithdrawOrUnlockParams } from "./CkbSdkService.types";
+import { CKB_TESTNET_URL, INDEXER_TESTNET_URL, CKB_MAINNET_URL, INDEXER_MAINNET_URL } from "@env";
 import { TokenAmount, TokenType } from "module/token/types";
 
 export function getTokenIndexTypeFromScript(scriptType: ScriptType): number {
@@ -32,19 +32,21 @@ export function getTokenTypeFromScript(scriptType: ScriptType) {
     return getTokenTypeFromIndex(tokenIndex, scriptType);
 }
 
-export const connectionService = new ConnectionService(CKB_URL, INDEXER_URL, Environments.Testnet);
+export const testnetConnectionService = new ConnectionService(CKB_TESTNET_URL, INDEXER_TESTNET_URL, Environments.Testnet);
+export const mainnetConnectionService = new ConnectionService(CKB_MAINNET_URL, INDEXER_MAINNET_URL, Environments.Mainnet);
 
 export class CKBSDKService {
     private connectionService: ConnectionService;
     private wallet: WalletService;
 
     constructor(
+        chain: Chain,
         mnemonic: string,
         walletState?: WalletState,
         onSync?: (walletState: WalletState) => Promise<void>,
         onSyncStart?: () => void,
     ) {
-        this.connectionService = connectionService;
+        this.connectionService = chain === "testnet" ? testnetConnectionService : mainnetConnectionService;
         this.wallet = new WalletService(this.connectionService, mnemonic, walletState, onSync, onSyncStart);
     }
 

--- a/src/module/common/service/CkbSdkService.types.ts
+++ b/src/module/common/service/CkbSdkService.types.ts
@@ -1,5 +1,7 @@
 import { DAOUnlockableAmount, FeeRate, Transaction } from "ckb-peersyst-sdk";
 
+export type Chain = "mainnet" | "testnet";
+
 export interface DepositInDAOParams {
     amount: bigint | number;
     mnemonic: string[];

--- a/src/module/dao/query/useDepositInDAO.ts
+++ b/src/module/dao/query/useDepositInDAO.ts
@@ -2,14 +2,16 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { DepositInDAOParams } from "module/common/service/CkbSdkService.types";
 import { useMutation } from "react-query";
 import useAddUncommittedTransaction from "module/transaction/query/useAddUncommitedTransaction";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useDepositInDAO = (index: number) => {
+    const network = useSelectedNetwork();
     const addUncommittedTransaction = useAddUncommittedTransaction();
 
     return useMutation(async (params: DepositInDAOParams) => {
-        const serviceInstance = serviceInstancesMap.get(index)!;
+        const serviceInstance = serviceInstancesMap.get(index)![network];
         const hash = await serviceInstance.depositInDAO(params);
-        if (hash) await addUncommittedTransaction(index, hash);
+        if (hash) await addUncommittedTransaction(index, network, hash);
     });
 };
 

--- a/src/module/dao/query/useGetDAOBalance.ts
+++ b/src/module/dao/query/useGetDAOBalance.ts
@@ -3,14 +3,16 @@ import { QueryResult } from "query-utils";
 import { DAOBalance } from "ckb-peersyst-sdk";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useGetDAOBalance = (index?: number): QueryResult<DAOBalance> => {
+    const network = useSelectedNetwork();
     const selectedWallet = useSelectedWalletIndex();
     const usedIndex = index ?? selectedWallet;
     return useQuery(
-        ["daoBalance", usedIndex],
+        ["daoBalance", usedIndex, network],
         () => {
-            const serviceInstance = serviceInstancesMap.get(usedIndex);
+            const serviceInstance = serviceInstancesMap.get(usedIndex)?.[network];
             return serviceInstance?.getDAOBalance();
         },
         { refetchInterval: 15000 },

--- a/src/module/dao/query/useGetDAOUnlockableAmounts.ts
+++ b/src/module/dao/query/useGetDAOUnlockableAmounts.ts
@@ -3,13 +3,19 @@ import { QueryResult } from "query-utils";
 import { DAOUnlockableAmount } from "ckb-peersyst-sdk";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useGetDAOUnlockableAmounts = (index?: number): QueryResult<DAOUnlockableAmount[]> => {
+    const network = useSelectedNetwork();
     const selectedWalletIndex = useSelectedWalletIndex();
     const usedIndex = index ?? selectedWalletIndex;
-    return useQuery(["daoUnlockableAmounts", usedIndex], () => serviceInstancesMap.get(usedIndex)!.getDAOUnlockableAmounts() ?? [], {
-        refetchInterval: 15000,
-    });
+    return useQuery(
+        ["daoUnlockableAmounts", usedIndex, network],
+        () => serviceInstancesMap.get(usedIndex)![network].getDAOUnlockableAmounts() ?? [],
+        {
+            refetchInterval: 15000,
+        },
+    );
 };
 
 export default useGetDAOUnlockableAmounts;

--- a/src/module/dao/query/useWithdrawOrUnlock.ts
+++ b/src/module/dao/query/useWithdrawOrUnlock.ts
@@ -2,14 +2,16 @@ import { useMutation } from "react-query";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { WithdrawOrUnlockParams } from "module/common/service/CkbSdkService.types";
 import useAddUncommittedTransaction from "module/transaction/query/useAddUncommitedTransaction";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useWithdrawOrUnlock = (index: number) => {
+    const network = useSelectedNetwork();
     const addUncommittedTransaction = useAddUncommittedTransaction();
 
     return useMutation(async (params: WithdrawOrUnlockParams) => {
-        const serviceInstance = serviceInstancesMap.get(index)!;
+        const serviceInstance = serviceInstancesMap.get(index)![network];
         const hash = await serviceInstance.withdrawOrUnlock(params);
-        if (hash) await addUncommittedTransaction(index, hash);
+        if (hash) await addUncommittedTransaction(index, network, hash);
     });
 };
 export default useWithdrawOrUnlock;

--- a/src/module/dao/screen/DepositConfirmationScreen/DepositConfirmationScreen.tsx
+++ b/src/module/dao/screen/DepositConfirmationScreen/DepositConfirmationScreen.tsx
@@ -14,17 +14,19 @@ import settingsState from "module/settings/state/SettingsState";
 import { convertCKBToShannons } from "module/wallet/utils/convertCKBToShannons";
 import ConfirmPinModal from "module/settings/components/core/ConfirmPinModal/ConfirmPinModal";
 import { useState } from "react";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const DepositConfirmationScreen = (): JSX.Element => {
     const [showConfirmation, setShowConfirmation] = useState(false);
     const [loading, setLoading] = useState(false);
+    const network = useSelectedNetwork();
     const { amount, fee: feeInCKB, senderWalletIndex } = useRecoilValue(sendState);
     const {
         state: { wallets },
     } = useWalletState();
     const senderWallet = wallets[senderWalletIndex!];
     const { name: senderName } = senderWallet;
-    const serviceInstance = serviceInstancesMap.get(senderWalletIndex!);
+    const serviceInstance = serviceInstancesMap.get(senderWalletIndex!)?.[network];
     const { fee: feeInShannons } = useRecoilValue(settingsState);
     const { mutate: depositInDAO, isLoading, isSuccess, isError } = useDepositInDAO(senderWalletIndex!);
     const { hideModal } = useModal();

--- a/src/module/dao/screen/DepositConfirmationScreen/DepositSummary.tsx
+++ b/src/module/dao/screen/DepositConfirmationScreen/DepositSummary.tsx
@@ -17,20 +17,22 @@ const DepositSummary = ({ amount, fee, senderName, senderAddress }: DepositSumma
 
     return (
         <BaseSendSummary amount={amount} fee={fee}>
-            <Col gap="3%" style={{ alignSelf: "flex-start" }}>
-                <SummaryField label={translate("from")}>{senderName + " - " + formatAddress(senderAddress, "middle", 3)}</SummaryField>
-                <SummaryField label={translate("estimated_apc")}>
-                    {daoBalance !== undefined ? `${getAPC(daoBalance)}%` : `${translate("loading_apc")}...`}
-                </SummaryField>
-            </Col>
-            <Col>
-                <SummaryText variant="body2" textAlign="center">
-                    <SummaryText variant="body2" fontWeight="bold" textAlign="center">
-                        {`${translate("attention")} `}
+            <>
+                <Col gap="3%" style={{ alignSelf: "flex-start" }}>
+                    <SummaryField label={translate("from")}>{senderName + " - " + formatAddress(senderAddress, "middle", 3)}</SummaryField>
+                    <SummaryField label={translate("estimated_apc")}>
+                        {daoBalance !== undefined ? `${getAPC(daoBalance)}%` : `${translate("loading_apc")}...`}
+                    </SummaryField>
+                </Col>
+                <Col>
+                    <SummaryText variant="body2" textAlign="center">
+                        <SummaryText variant="body2" fontWeight="bold" textAlign="center">
+                            {`${translate("attention")} `}
+                        </SummaryText>
+                        {translate("deposit_summary_warning")}
                     </SummaryText>
-                    {translate("deposit_summary_warning")}
-                </SummaryText>
-            </Col>
+                </Col>
+            </>
         </BaseSendSummary>
     );
 };

--- a/src/module/dao/screen/WithdrawConfirmationScreen/WithdrawConfirmationScreen.tsx
+++ b/src/module/dao/screen/WithdrawConfirmationScreen/WithdrawConfirmationScreen.tsx
@@ -13,6 +13,7 @@ import { useMemo, useState } from "react";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { convertShannonsToCKB } from "module/wallet/utils/convertShannonsToCKB";
 import ConfirmPinModal from "module/settings/components/core/ConfirmPinModal/ConfirmPinModal";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 interface WithdrawConfirmationScreenProps {
     withdrawInfo: WithdrawSummaryType;
@@ -25,6 +26,7 @@ const WithdrawConfirmationScreen = ({
     const [showConfirmation, setShowConfirmation] = useState(false);
     const [loading, setLoading] = useState(false);
     const { hideModal } = useModal();
+    const network = useSelectedNetwork();
     const {
         state: { wallets },
     } = useWalletState();
@@ -33,7 +35,7 @@ const WithdrawConfirmationScreen = ({
 
     //Variables
     const { name: receiverName } = wallets[receiverIndex]; //Receiver info
-    const serviceInstance = useMemo(() => serviceInstancesMap.get(receiverIndex), [receiverIndex]);
+    const serviceInstance = useMemo(() => serviceInstancesMap.get(receiverIndex)?.[network], [receiverIndex]);
     const { compensation = BigInt(0), amount = BigInt(0) } = unlockableDeposits[depositIndex] || {}; //Deposit info
 
     //Functions

--- a/src/module/nft/query/useGetNfts.ts
+++ b/src/module/nft/query/useGetNfts.ts
@@ -2,12 +2,14 @@ import { useQuery, UseQueryResult } from "react-query";
 import { Nft } from "module/nft/types";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 export default function (index?: number): UseQueryResult<Nft[]> {
+    const network = useSelectedNetwork();
     const selectedWallet = useSelectedWalletIndex();
     const usedIndex = index ?? selectedWallet;
-    return useQuery(["nfts", usedIndex], () => {
-        const serviceInstance = serviceInstancesMap.get(usedIndex);
+    return useQuery(["nfts", usedIndex, network], () => {
+        const serviceInstance = serviceInstancesMap.get(usedIndex)?.[network];
         return serviceInstance?.getNfts();
     });
 }

--- a/src/module/settings/components/core/DeleteOneWallet/DeleteOneWallet.tsx
+++ b/src/module/settings/components/core/DeleteOneWallet/DeleteOneWallet.tsx
@@ -53,7 +53,8 @@ const DeleteOneWallet = () => {
                         for (let i = 0; i < serviceInstancesSize; i++) {
                             if (i > index) {
                                 serviceInstancesMap.set(i - 1, serviceInstancesMap.get(i)!);
-                                await invalidateWalletQueries(i - 1);
+                                await invalidateWalletQueries(i - 1, "testnet");
+                                await invalidateWalletQueries(i - 1, "mainnet");
                             }
                         }
                         //Delete last service instance and queries from last position

--- a/src/module/settings/components/core/SelectNetwork/SelectNetwork.tsx
+++ b/src/module/settings/components/core/SelectNetwork/SelectNetwork.tsx
@@ -3,6 +3,8 @@ import SelectGroup, { optionType } from "module/common/component/input/SelectGro
 import settingsState, { NetworkType } from "module/settings/state/SettingsState";
 import { useRecoilState } from "recoil";
 import { SettingsStorage } from "module/settings/SettingsStorage";
+import { serviceInstancesMap } from "module/wallet/state/WalletState";
+import { ENABLE_MAINNET } from "@env";
 
 const SelectNetwork = (): JSX.Element => {
     const networkOptions: optionType[] = [
@@ -16,13 +18,21 @@ const SelectNetwork = (): JSX.Element => {
         },
     ];
     const [settings, setSettings] = useRecoilState(settingsState);
+
     const handleNetworkChange = (value: NetworkType) => {
+        //Use another thread
+        setTimeout(async () => {
+            for (let i = 0; i < serviceInstancesMap.size; i += 1) {
+                await serviceInstancesMap.get(i)?.[value]?.synchronize();
+            }
+        });
         setSettings({ ...settings, network: value as NetworkType });
         SettingsStorage.set({ network: value });
     };
 
     return (
         <SelectGroup
+            disabled={ENABLE_MAINNET !== "true"}
             options={networkOptions}
             value={settings.network}
             label={translate("select_your_network")}

--- a/src/module/settings/hook/useSelectedNetwork.ts
+++ b/src/module/settings/hook/useSelectedNetwork.ts
@@ -1,0 +1,6 @@
+import settingsState, { NetworkType } from "module/settings/state/SettingsState";
+import { useRecoilValue } from "recoil";
+
+export default function (): NetworkType {
+    return useRecoilValue(settingsState).network;
+}

--- a/src/module/settings/screen/GeneralSettingsScreen.tsx
+++ b/src/module/settings/screen/GeneralSettingsScreen.tsx
@@ -5,13 +5,13 @@ import { Col } from "react-native-components";
 import SelectFee from "../components/core/SelectFee/SelectFee";
 import SelectFiat from "../components/core/SelectFiat/SelectFiat";
 import SelectLocale from "../components/core/SelectLocale/SelectLocale";
-/* import SelectNetwork from "../components/core/SelectNetwork/SelectNetwork"; */
+import SelectNetwork from "../components/core/SelectNetwork/SelectNetwork";
 
 const GeneralSettingsScreen = ({ navigation }: BottomTabScreenNavigatonProps): JSX.Element => {
     return (
         <BaseSecondaryScreen navigation={navigation} title={translate("general_settings")} back={true}>
             <Col gap={20}>
-                {/* <SelectNetwork /> */}
+                <SelectNetwork />
                 <SelectFee />
                 <SelectFiat />
                 <SelectLocale />

--- a/src/module/settings/state/SettingsState.ts
+++ b/src/module/settings/state/SettingsState.ts
@@ -2,10 +2,11 @@ import { FeeRate } from "ckb-peersyst-sdk";
 import { LocaleType } from "locale";
 import getDefaultLocale from "locale/utils/getDefaultLocale";
 import { atom } from "recoil";
+import { Chain } from "module/common/service/CkbSdkService.types";
 
 export type FiatCurrencyType = "cny" | "usd" | "eur" | "jpy" | "gbp";
 
-export type NetworkType = "testnet" | "mainnet";
+export type NetworkType = Chain;
 
 export type FeeType = FeeRate.SLOW | FeeRate.NORMAL | FeeRate.FAST;
 

--- a/src/module/token/query/useGetTokens.ts
+++ b/src/module/token/query/useGetTokens.ts
@@ -3,12 +3,14 @@ import { useQuery } from "react-query";
 import { TokenAmount } from "../types";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useGetTokens = (index?: number): QueryResult<TokenAmount[]> => {
+    const network = useSelectedNetwork();
     const selectedWallet = useSelectedWalletIndex();
     const usedIndex = index ?? selectedWallet;
-    return useQuery(["tokens", usedIndex], () => {
-        const serviceInstance = serviceInstancesMap.get(usedIndex);
+    return useQuery(["tokens", usedIndex, network], () => {
+        const serviceInstance = serviceInstancesMap.get(usedIndex)?.[network];
         return serviceInstance?.getTokensBalance();
     });
 };

--- a/src/module/transaction/component/display/QRCode/QRCode.tsx
+++ b/src/module/transaction/component/display/QRCode/QRCode.tsx
@@ -3,10 +3,12 @@ import { Row } from "react-native-components";
 import QRCodeBase from "react-native-qrcode-svg";
 import useSelectedWallet from "module/wallet/hook/useSelectedWallet";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const QRCode = (): JSX.Element => {
+    const network = useSelectedNetwork();
     const { index } = useSelectedWallet();
-    const serviceInstance = serviceInstancesMap.get(index);
+    const serviceInstance = serviceInstancesMap.get(index)?.[network];
     const { height: screenHeight } = useWindowDimensions();
     const height = screenHeight * 0.35;
     return (

--- a/src/module/transaction/component/display/ReceiveCard/ReceiveCard.tsx
+++ b/src/module/transaction/component/display/ReceiveCard/ReceiveCard.tsx
@@ -7,6 +7,7 @@ import GoBack from "../../navigation/GoBack";
 import ReceiveModal from "../../core/ReceiveModal/ReceiveModal";
 import useSelectedWallet from "module/wallet/hook/useSelectedWallet";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const ReceiveCardContent = styled(Col, { justifyContent: "space-between" })(({ dimensions }) => ({
     height: dimensions.height * 0.3,
@@ -19,8 +20,9 @@ const TextAddress = styled(Typography, { textTransform: "uppercase" })(() => ({
 }));
 
 const ReceiveCard = (): JSX.Element => {
+    const network = useSelectedNetwork();
     const { index } = useSelectedWallet();
-    const serviceInstance = serviceInstancesMap.get(index);
+    const serviceInstance = serviceInstancesMap.get(index)?.[network];
     const address = serviceInstance?.getAddress();
     const { hideModal } = useModal();
 

--- a/src/module/transaction/query/useAddUncommitedTransaction.ts
+++ b/src/module/transaction/query/useAddUncommitedTransaction.ts
@@ -1,23 +1,30 @@
 import { WalletStorage } from "module/wallet/WalletStorage";
 import { useSetRecoilState } from "recoil";
 import walletState from "module/wallet/state/WalletState";
+import { NetworkType } from "module/settings/state/SettingsState";
 
-const useAddUncommittedTransaction = (): ((index: number, hash: string) => Promise<void>) => {
+const useAddUncommittedTransaction = (): ((index: number, chain: NetworkType, hash: string) => Promise<void>) => {
     const setWalletState = useSetRecoilState(walletState);
 
-    return async (index, hash) => {
+    return async (index, chain, hash) => {
         setWalletState((state) => ({
             ...state,
-            wallets: state.wallets.map((w) =>
-                w.index === index
-                    ? {
-                          ...w,
-                          uncommittedTransactionHashes: [...(w.uncommittedTransactionHashes || []), hash],
-                      }
-                    : w,
-            ),
+            wallets: state.wallets.map((w) => {
+                if (w.index !== index) return w;
+                else {
+                    const networkInfo = w[chain];
+                    const uncommittedTransactionHashes = w?.[chain]?.uncommittedTransactionHashes || [];
+                    return {
+                        ...w,
+                        [chain]: {
+                            ...networkInfo,
+                            uncommittedTransactionHashes: [...uncommittedTransactionHashes, hash],
+                        },
+                    };
+                }
+            }),
         }));
-        await WalletStorage.addUncommittedTransactionHash(index, hash);
+        await WalletStorage.addUncommittedTransactionHash(index, chain, hash);
     };
 };
 

--- a/src/module/transaction/query/useGetTransactions.ts
+++ b/src/module/transaction/query/useGetTransactions.ts
@@ -4,6 +4,7 @@ import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
 import useUncommittedTransactions from "module/transaction/query/useUncommittedTransactions";
 import { FullTransaction } from "module/common/service/CkbSdkService.types";
 import { useMemo } from "react";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 export interface UseGetTransactionsOptions {
     index?: number;
@@ -11,11 +12,12 @@ export interface UseGetTransactionsOptions {
 }
 
 const useGetTransactions = ({ index, filter }: UseGetTransactionsOptions = {}) => {
+    const network = useSelectedNetwork();
     const selectedWallet = useSelectedWalletIndex();
     const usedIndex = index ?? selectedWallet;
     const { data: uncommitedTransactions = [], isLoading: uncommitedTransactionsLoading } = useUncommittedTransactions(usedIndex);
-    const { data: transactions = [], isLoading: transactionsLoading } = useQuery(["transactions", usedIndex], () => {
-        const serviceInstance = serviceInstancesMap.get(usedIndex);
+    const { data: transactions = [], isLoading: transactionsLoading } = useQuery(["transactions", usedIndex, network], () => {
+        const serviceInstance = serviceInstancesMap.get(usedIndex)?.[network];
         return serviceInstance?.getTransactions().reverse();
     });
 

--- a/src/module/transaction/query/useSendTransaction.ts
+++ b/src/module/transaction/query/useSendTransaction.ts
@@ -3,15 +3,17 @@ import { SendTransactionParams } from "module/common/service/CkbSdkService.types
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
 import useAddUncommittedTransaction from "module/transaction/query/useAddUncommitedTransaction";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useSendTransaction = () => {
+    const network = useSelectedNetwork();
     const selectedWallet = useSelectedWalletIndex();
     const addUncommittedTransaction = useAddUncommittedTransaction();
 
     return useMutation(async (params: SendTransactionParams) => {
-        const serviceInstance = serviceInstancesMap.get(selectedWallet)!;
+        const serviceInstance = serviceInstancesMap.get(selectedWallet)![network];
         const hash = await serviceInstance.sendTransaction(params);
-        if (hash) await addUncommittedTransaction(selectedWallet, hash);
+        if (hash) await addUncommittedTransaction(selectedWallet, network, hash);
     });
 };
 

--- a/src/module/transaction/query/useUncommittedTransactions.ts
+++ b/src/module/transaction/query/useUncommittedTransactions.ts
@@ -8,24 +8,28 @@ import { TransactionStatus } from "module/sdk";
 import { useSetRecoilState } from "recoil";
 import { WalletStorage } from "module/wallet/WalletStorage";
 import { useRef } from "react";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useUncommittedTransactions = (index?: number): QueryResult<FullTransaction[]> => {
+    const network = useSelectedNetwork();
     const selectedWallet = useSelectedWalletIndex();
     const usedIndex = index ?? selectedWallet;
-    const { uncommittedTransactionHashes } = useWallet(usedIndex);
+    const wallet = useWallet(usedIndex);
+    const { uncommittedTransactionHashes } = wallet[network] || {};
     const setWalletState = useSetRecoilState(walletState);
     const rejectedHashes: string[] = useRef([]).current;
 
     return useQuery(
-        ["uncommittedTransactions", usedIndex, uncommittedTransactionHashes],
+        ["uncommittedTransactions", usedIndex, network, uncommittedTransactionHashes],
         async () => {
             if (!uncommittedTransactionHashes) return [];
 
-            const serviceInstance = serviceInstancesMap.get(usedIndex)!;
+            const serviceInstance = serviceInstancesMap.get(usedIndex)![network];
 
             const updatedUncommittedTransactionHashes: string[] = [];
             let shouldSync = false;
             const uncommittedTransactions: FullTransaction[] = [];
+
             for (const hash of uncommittedTransactionHashes) {
                 const tx = await serviceInstance.getTransaction(hash);
                 if (tx.status !== TransactionStatus.COMMITTED) {
@@ -33,12 +37,12 @@ const useUncommittedTransactions = (index?: number): QueryResult<FullTransaction
                     updatedUncommittedTransactionHashes.push(hash);
                     // If rejected keep it in the list but remove it from storage in order to show it just in the current session
                     if (tx.status === TransactionStatus.REJECTED && !rejectedHashes.find((h) => h === hash)) {
-                        await WalletStorage.removeUncommittedTransactionHash(usedIndex, hash);
+                        await WalletStorage.removeUncommittedTransactionHash(usedIndex, network, hash);
                         rejectedHashes.push(hash);
                     }
                     // If committed remove it and sync in order to refresh data and refetch useGetTransactiions
                 } else {
-                    await WalletStorage.removeUncommittedTransactionHash(usedIndex, hash);
+                    await WalletStorage.removeUncommittedTransactionHash(usedIndex, network, hash);
                     shouldSync = true;
                 }
             }
@@ -46,9 +50,19 @@ const useUncommittedTransactions = (index?: number): QueryResult<FullTransaction
                 await serviceInstance.synchronize();
                 setWalletState((state) => ({
                     ...state,
-                    wallets: state.wallets.map((w) =>
-                        w.index === usedIndex ? { ...w, uncommittedTransactionHashes: updatedUncommittedTransactionHashes } : w,
-                    ),
+                    wallets: state.wallets.map((w) => {
+                        if (w.index !== usedIndex) return w;
+                        else {
+                            const networkInfo = w[network];
+                            return {
+                                ...w,
+                                [network]: {
+                                    ...networkInfo,
+                                    uncommittedTransactionHashes: updatedUncommittedTransactionHashes,
+                                },
+                            };
+                        }
+                    }),
                 }));
             }
             return uncommittedTransactions;

--- a/src/module/transaction/screen/SendConfirmationScreen/SendConfirmationScreen.tsx
+++ b/src/module/transaction/screen/SendConfirmationScreen/SendConfirmationScreen.tsx
@@ -14,10 +14,12 @@ import settingsState from "module/settings/state/SettingsState";
 import { convertCKBToShannons } from "module/wallet/utils/convertCKBToShannons";
 import ConfirmPinModal from "module/settings/components/core/ConfirmPinModal/ConfirmPinModal";
 import { useState } from "react";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const SendConfirmationScreen = (): JSX.Element => {
     const [showConfirmation, setShowConfirmation] = useState(false);
     const [loading, setLoading] = useState(false);
+    const network = useSelectedNetwork();
     const { amount, fee: feeInCKB, senderWalletIndex, receiverAddress, message } = useRecoilValue(sendState);
     const { fee: feeInShannons } = useRecoilValue(settingsState);
     const {
@@ -25,7 +27,7 @@ const SendConfirmationScreen = (): JSX.Element => {
     } = useWalletState();
     const senderWallet = wallets[senderWalletIndex!];
     const { name: senderName, index } = senderWallet;
-    const serviceInstance = serviceInstancesMap.get(index);
+    const serviceInstance = serviceInstancesMap.get(index)?.[network];
     const { mutate: sendTransaction, isLoading, isSuccess, isError } = useSendTransaction();
     const { hideModal } = useModal();
 

--- a/src/module/wallet/component/core/AddWalletModal/AddWalletModal.tsx
+++ b/src/module/wallet/component/core/AddWalletModal/AddWalletModal.tsx
@@ -6,6 +6,7 @@ import { WalletStorage } from "module/wallet/WalletStorage";
 import GlassNavigatorModal from "module/common/component/navigation/GlassNavigatorModal/GlassNavigatorModal";
 import useServiceInstanceCreation from "module/wallet/hook/useServiceInstanceCreation";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 export interface AddWalletModalProps extends ExposedBackdropProps {
     title: string;
@@ -21,6 +22,7 @@ const AddWalletModal = ({ onExited, onClose, children: renderProps, title, onBac
     } = useCreateWallet();
     const { setState: setWalletState } = useWalletState();
     const createServiceInstance = useServiceInstanceCreation();
+    const network = useSelectedNetwork();
 
     const handleClose = () => {
         setOpen(false);
@@ -51,7 +53,7 @@ const AddWalletModal = ({ onExited, onClose, children: renderProps, title, onBac
 
             //Use another thread
             setTimeout(async () => {
-                await serviceInstancesMap.get(newWallet.index)?.synchronize();
+                await serviceInstancesMap.get(newWallet.index)?.[network]?.synchronize();
             });
         }
         handleClose();

--- a/src/module/wallet/component/core/WalletCard/WalletCard.tsx
+++ b/src/module/wallet/component/core/WalletCard/WalletCard.tsx
@@ -41,6 +41,7 @@ const WalletCard = ({ wallet: { name, index, colorIndex, synchronizing } }: Wall
         impactAsync(ImpactFeedbackStyle.Medium);
         setCurrencyMode((value) => !value);
     };
+
     return (
         <WalletCardRoot color={color}>
             <WalletContent>

--- a/src/module/wallet/component/core/WalletCard/WalletCardHeader/WalletCardHeader.tsx
+++ b/src/module/wallet/component/core/WalletCard/WalletCardHeader/WalletCardHeader.tsx
@@ -2,6 +2,7 @@ import { translate } from "locale";
 import { Row } from "react-native-components";
 import { WalletCardTitle, CopyIcon, EditIcon } from "../WalletCard.styles";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 interface AccountCardHeaderProps {
     index: number;
@@ -9,7 +10,8 @@ interface AccountCardHeaderProps {
 }
 
 const WalletCardHeader = ({ index, name }: AccountCardHeaderProps): JSX.Element => {
-    const serviceInstance = serviceInstancesMap.get(index);
+    const network = useSelectedNetwork();
+    const serviceInstance = serviceInstancesMap.get(index)?.[network];
     return (
         <Row justifyContent="space-between" alignItems="center">
             <EditIcon index={index} />

--- a/src/module/wallet/hook/useCkbSync.ts
+++ b/src/module/wallet/hook/useCkbSync.ts
@@ -1,10 +1,12 @@
 import useSelectedWallet from "module/wallet/hook/useSelectedWallet";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useCkbSync = (index?: number) => {
+    const network = useSelectedNetwork();
     const { synchronizing = false, index: selectedWalletIndex } = useSelectedWallet() || {};
     const synchronize = async () => {
-        await serviceInstancesMap.get(index ?? selectedWalletIndex)?.synchronize();
+        await serviceInstancesMap.get(index ?? selectedWalletIndex)?.[network]?.synchronize();
     };
 
     return {

--- a/src/module/wallet/hook/useServiceInstanceCreation.ts
+++ b/src/module/wallet/hook/useServiceInstanceCreation.ts
@@ -4,36 +4,50 @@ import { WalletState } from "module/sdk";
 import { WalletStorage } from "module/wallet/WalletStorage";
 import { useSetRecoilState } from "recoil";
 import useWalletQueriesInvalidation from "module/wallet/hook/useWalletQueriesInvalidation";
+import { Chain } from "module/common/service/CkbSdkService.types";
 
-const useServiceInstanceCreation = (): ((walletIndex: number, mnemonic: string[], initialState?: WalletState) => Promise<void>) => {
+const useServiceInstanceCreation = (): ((
+    walletIndex: number,
+    mnemonic: string[],
+    testnetInitialState?: WalletState,
+    mainnetInitialState?: WalletState,
+) => Promise<void>) => {
     const setWalletState = useSetRecoilState(walletState);
     const invalidateWalletQueries = useWalletQueriesInvalidation();
 
-    return async (index, mnemonic, initialState) => {
+    return async (index, mnemonic, testnetInitialState, mainnetInitialState) => {
         if (!serviceInstancesMap.has(index)) {
-            serviceInstancesMap.set(
-                index,
-                new CKBSDKService(
-                    mnemonic.join(" "),
-                    initialState,
-                    async (walletState: WalletState) => {
-                        await WalletStorage.setInitialState(index, walletState);
-                        await invalidateWalletQueries(index);
-                        setWalletState((state) => ({
-                            ...state,
-                            wallets: state.wallets.map((w) =>
-                                w.index === index ? { ...w, initialState: walletState, synchronizing: false } : w,
-                            ),
-                        }));
-                    },
-                    () => {
-                        setWalletState((state) => ({
-                            ...state,
-                            wallets: state.wallets.map((w) => (w.index === index ? { ...w, synchronizing: true } : w)),
-                        }));
-                    },
+            const stringMnemonic = mnemonic.join(" ");
+            const onSync = async (chain: Chain, walletState: WalletState) => {
+                await WalletStorage.setInitialState(index, chain, walletState);
+                await invalidateWalletQueries(index, chain);
+                setWalletState((state) => ({
+                    ...state,
+                    wallets: state.wallets.map((w) => (w.index === index ? { ...w, initialState: walletState, synchronizing: false } : w)),
+                }));
+            };
+            const onSyncStart = () => {
+                setWalletState((state) => ({
+                    ...state,
+                    wallets: state.wallets.map((w) => (w.index === index ? { ...w, synchronizing: true } : w)),
+                }));
+            };
+            serviceInstancesMap.set(index, {
+                testnet: new CKBSDKService(
+                    "testnet",
+                    stringMnemonic,
+                    testnetInitialState,
+                    (walletState) => onSync("testnet", walletState),
+                    onSyncStart,
                 ),
-            );
+                mainnet: new CKBSDKService(
+                    "mainnet",
+                    stringMnemonic,
+                    mainnetInitialState,
+                    (walletState) => onSync("mainnet", walletState),
+                    onSyncStart,
+                ),
+            });
         }
     };
 };

--- a/src/module/wallet/hook/useWalletQueriesInvalidation.ts
+++ b/src/module/wallet/hook/useWalletQueriesInvalidation.ts
@@ -1,15 +1,16 @@
 import { useQueryClient } from "react-query";
+import { NetworkType } from "module/settings/state/SettingsState";
 
-const useWalletQueriesInvalidation = (): ((index: number) => Promise<void>) => {
+const useWalletQueriesInvalidation = (): ((index: number, chain: NetworkType) => Promise<void>) => {
     const queryClient = useQueryClient();
-    return async (index) => {
+    return async (index, chain) => {
         await Promise.all([
-            queryClient.invalidateQueries(["transactions", index], { refetchInactive: true, exact: true }),
-            queryClient.invalidateQueries(["tokens", index], { refetchInactive: true, exact: true }),
-            queryClient.invalidateQueries(["nfts", index], { refetchInactive: true, exact: true }),
-            queryClient.invalidateQueries(["balance", index], { refetchInactive: true, exact: true }),
-            queryClient.invalidateQueries(["daoBalance", index], { refetchInactive: true, exact: true }),
-            queryClient.invalidateQueries(["daoUnlockableAmounts", index], { refetchInactive: true, exact: true }),
+            queryClient.invalidateQueries(["transactions", index, chain], { refetchInactive: true, exact: true }),
+            queryClient.invalidateQueries(["tokens", index, chain], { refetchInactive: true, exact: true }),
+            queryClient.invalidateQueries(["nfts", index, chain], { refetchInactive: true, exact: true }),
+            queryClient.invalidateQueries(["balance", index, chain], { refetchInactive: true, exact: true }),
+            queryClient.invalidateQueries(["daoBalance", index, chain], { refetchInactive: true, exact: true }),
+            queryClient.invalidateQueries(["daoUnlockableAmounts", index, chain], { refetchInactive: true, exact: true }),
         ]);
     };
 };

--- a/src/module/wallet/hook/useWalletQueriesRemoval.ts
+++ b/src/module/wallet/hook/useWalletQueriesRemoval.ts
@@ -3,12 +3,13 @@ import { useQueryClient } from "react-query";
 const useWalletQueriesRemoval = (): ((index: number) => void) => {
     const queryClient = useQueryClient();
     return async (index) => {
-        queryClient.removeQueries(["transactions", index], { exact: true });
-        queryClient.removeQueries(["tokens", index], { exact: true });
-        queryClient.removeQueries(["nfts", index], { exact: true });
-        queryClient.removeQueries(["balance", index], { exact: true });
-        queryClient.removeQueries(["daoBalance", index], { exact: true });
-        queryClient.removeQueries(["daoUnlockableAmounts", index], { exact: true });
+        queryClient.removeQueries(["transactions", index]);
+        queryClient.removeQueries(["tokens", index]);
+        queryClient.removeQueries(["nfts", index]);
+        queryClient.removeQueries(["balance", index]);
+        queryClient.removeQueries(["daoBalance", index]);
+        queryClient.removeQueries(["daoUnlockableAmounts", index]);
+        queryClient.removeQueries(["uncommittedTransactions", index]);
     };
 };
 

--- a/src/module/wallet/query/useGetBalance.ts
+++ b/src/module/wallet/query/useGetBalance.ts
@@ -1,11 +1,15 @@
 import { useQuery } from "react-query";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import useSelectedWalletIndex from "module/wallet/hook/useSelectedWalletIndex";
+import useSelectedNetwork from "module/settings/hook/useSelectedNetwork";
 
 const useGetBalance = (index?: number) => {
+    const network = useSelectedNetwork();
     const selectedWallet = useSelectedWalletIndex();
     const usedIndex = index ?? selectedWallet;
-    return useQuery(["balance", usedIndex], () => serviceInstancesMap.get(usedIndex)?.getCKBBalance(), { refetchInterval: 1500 });
+    return useQuery(["balance", usedIndex, network], () => serviceInstancesMap.get(usedIndex)?.[network]?.getCKBBalance(), {
+        refetchInterval: 1500,
+    });
 };
 
 export default useGetBalance;

--- a/src/module/wallet/screen/CreateWalletSuccessScreen.tsx
+++ b/src/module/wallet/screen/CreateWalletSuccessScreen.tsx
@@ -38,7 +38,7 @@ const CreateWalletSuccessScreen = (): JSX.Element => {
 
             //Use another thread
             setTimeout(async () => {
-                await serviceInstancesMap.get(0)?.synchronize();
+                await serviceInstancesMap.get(0)?.[defaultSettingsState.network]?.synchronize();
             });
 
             resetCreateWalletState();

--- a/src/module/wallet/state/WalletState.ts
+++ b/src/module/wallet/state/WalletState.ts
@@ -2,7 +2,7 @@ import { atom } from "recoil";
 import { StorageWallet } from "module/wallet/WalletStorage";
 import { CKBSDKService } from "module/common/service/CkbSdkService";
 
-export const serviceInstancesMap = new Map<number, CKBSDKService>();
+export const serviceInstancesMap = new Map<number, { testnet: CKBSDKService; mainnet: CKBSDKService }>();
 
 export type Wallet = Omit<StorageWallet, "mnemonic"> & { synchronizing?: boolean };
 

--- a/test/integration/AddWallet/Create.spec.tsx
+++ b/test/integration/AddWallet/Create.spec.tsx
@@ -15,7 +15,7 @@ import { MnemonicMocked } from "mocks/MnemonicMocked";
 describe("AddWallet - Create", () => {
     const mnemonicArr = ["Pizza", "Taco", "Fries"];
     jest.setTimeout(20000);
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     beforeAll(() => {
         jest.spyOn(WalletService, "createNewMnemonic").mockReturnValue(mnemonicArr.join(" "));

--- a/test/setup.tsx
+++ b/test/setup.tsx
@@ -60,3 +60,7 @@ jest.mock("../src/module/common/component/base/feedback/Backdrop/Backdrop", () =
     };
     return MockBackdrop;
 });
+
+jest.mock("module/settings/hook/useSelectedNetwork", () => {
+    return () => "testnet";
+});

--- a/test/unit/src/module/dao/component/core/DAOCard.spec.tsx
+++ b/test/unit/src/module/dao/component/core/DAOCard.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("Test for the DAO Card", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterAll(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("Test for the DAO Card", () => {
 
     test("Renders correctly", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getDAOBalance").mockReturnValue(SuccessApiCall(MockedDAOBalance));
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
             totalBalance: 20000,

--- a/test/unit/src/module/dao/component/core/DAOCardBalance.spec.tsx
+++ b/test/unit/src/module/dao/component/core/DAOCardBalance.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("DAO Card balance test", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterAll(() => {
         jest.restoreAllMocks();
@@ -18,12 +18,12 @@ describe("DAO Card balance test", () => {
 
     test("Renders correctly", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getDAOBalance").mockReturnValue(SuccessApiCall(MockedDAOBalance));
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
-            totalBalance: BigInt(20000),
-            occupiedBalance: BigInt(9600),
-            freeBalance: BigInt(12635),
+            totalBalance: 20000,
+            occupiedBalance: 9600,
+            freeBalance: 12635,
         });
 
         const screen = render(<DAOCardBalance />);

--- a/test/unit/src/module/dao/component/core/DAOCompletedWithdrawalsList.spec.tsx
+++ b/test/unit/src/module/dao/component/core/DAOCompletedWithdrawalsList.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("DAOCompletedWithdrawalsList tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("DAOCompletedWithdrawalsList tests", () => {
 
     beforeEach(() => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
     });
 
     test("Renders correctly with tx", async () => {

--- a/test/unit/src/module/dao/component/core/DAODepositsList.spec.tsx
+++ b/test/unit/src/module/dao/component/core/DAODepositsList.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("DAODepositsList tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("DAODepositsList tests", () => {
 
     beforeEach(() => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
     });
 
     test("Renders correctly with tx", async () => {

--- a/test/unit/src/module/dao/component/core/SelectDAOWallet.spec.tsx
+++ b/test/unit/src/module/dao/component/core/SelectDAOWallet.spec.tsx
@@ -7,7 +7,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("Test for the SelectDAOWallet", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterAll(() => {
         jest.restoreAllMocks();
@@ -15,11 +15,11 @@ describe("Test for the SelectDAOWallet", () => {
 
     test("Renders correctly", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
-            totalBalance: BigInt(20000),
-            occupiedBalance: BigInt(9600),
-            freeBalance: BigInt(14567),
+            totalBalance: 20000,
+            occupiedBalance: 9600,
+            freeBalance: 14567,
         });
         const screen = render(<SelectDAOWallet />);
         await waitFor(() => expect(screen.getAllByText("14,567")).toHaveLength(2));
@@ -29,11 +29,11 @@ describe("Test for the SelectDAOWallet", () => {
     test("Updates global selectedWallet correctly", async () => {
         const setSelectedWallet = jest.fn();
         jest.spyOn(UseWalletState, "default").mockReturnValue(createUseWalletStateMock({ setSelectedWallet }));
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
-            totalBalance: BigInt(20000),
-            occupiedBalance: BigInt(9600),
-            freeBalance: BigInt(14567),
+            totalBalance: 20000,
+            occupiedBalance: 9600,
+            freeBalance: 14567,
         });
         const screen = render(<SelectDAOWallet />);
         await waitFor(() => expect(screen.getAllByText("14,567")).toHaveLength(2));

--- a/test/unit/src/module/dao/component/navigation/DAOTabs.spec.tsx
+++ b/test/unit/src/module/dao/component/navigation/DAOTabs.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("DAOTabs tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("DAOTabs tests", () => {
 
     test("Renders correctly with deposits", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getTransactions").mockReturnValue(mockedDAODeposits);
         const screen = render(<DAOTabs />);
         await waitFor(() => expect(screen.getByText("01/01/2022 - 00:00")));
@@ -28,7 +28,7 @@ describe("DAOTabs tests", () => {
     });
     test("Renders correctly with completed withdrawals", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getTransactions").mockReturnValue(mockedDAOUnlocks);
         const screen = render(<DAOTabs />);
         await waitFor(() => expect(screen.getAllByText(translate("nothing_to_show"))));

--- a/test/unit/src/module/dao/screen/DepositConfirmationScreen.spec.tsx
+++ b/test/unit/src/module/dao/screen/DepositConfirmationScreen.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("DepositConfirmationScreen tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,8 +18,8 @@ describe("DepositConfirmationScreen tests", () => {
 
     test("Renders correctly", () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
         jest.spyOn(sdkInstance, "getAddress").mockReturnValue("0xMockedAddress");
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         const mockedWallet = mockedUseWallet.state.wallets[0];
         jest.spyOn(Recoil, "useRecoilValue").mockReturnValue({
             amount: 1000,

--- a/test/unit/src/module/dao/screen/DepositSummary.spec.tsx
+++ b/test/unit/src/module/dao/screen/DepositSummary.spec.tsx
@@ -10,10 +10,10 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("Test for the DepositSummary", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     beforeAll(() => {
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
     });
 
     afterEach(() => {
@@ -22,7 +22,7 @@ describe("Test for the DepositSummary", () => {
 
     test("Renders correctly", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getDAOBalance").mockReturnValue(SuccessApiCall(MockedDAOBalance));
         jest.spyOn(sdkInstance, "getAddress").mockReturnValue("0xMockedAddress");
         const screen = render(<DepositSummary senderAddress={"0xMockedAddress"} amount={1000} fee={"0.001"} senderName={"Peersyst"} />);

--- a/test/unit/src/module/dao/screen/SelectAccountAndDepositScreen.spec.tsx
+++ b/test/unit/src/module/dao/screen/SelectAccountAndDepositScreen.spec.tsx
@@ -15,12 +15,12 @@ import { wallet } from "mocks/wallet";
 import * as UseWalletState from "module/wallet/hook/useWalletState";
 
 describe("SelectAccountAndDepositScreen tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     beforeAll(() => {
         jest.spyOn(UseSelectedWallet, "default").mockReturnValue(wallet);
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
             totalBalance: 20000,
             occupiedBalance: 9600,

--- a/test/unit/src/module/dao/screen/WithdrawConfirmationScreen.spec.tsx
+++ b/test/unit/src/module/dao/screen/WithdrawConfirmationScreen.spec.tsx
@@ -12,10 +12,10 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("SelectAccountAndDepositScreen tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     beforeAll(() => {
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
         jest.spyOn(sdkInstance, "getDAOUnlockableAmounts").mockReturnValue(SuccessApiCall(MockedUnlockableAmounts));
         jest.spyOn(sdkInstance, "getAddress").mockReturnValue("0xMockedAddress");

--- a/test/unit/src/module/dao/screen/WithdrawModal.spec.tsx
+++ b/test/unit/src/module/dao/screen/WithdrawModal.spec.tsx
@@ -11,10 +11,10 @@ import { MnemonicMocked } from "mocks/MnemonicMocked";
 import { formatAddress } from "@peersyst/react-utils";
 
 describe("Withdraw modal test", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     beforeAll(() => {
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
     });
 
     beforeEach(() => {

--- a/test/unit/src/module/nft/component/core/NftsList/NftsList.spec.tsx
+++ b/test/unit/src/module/nft/component/core/NftsList/NftsList.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("NftsList tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("NftsList tests", () => {
 
     test("Renders correctly", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getNfts").mockReturnValue(SuccessApiCall(nfts));
 
         const screen = render(<NftsList />);
@@ -30,7 +30,7 @@ describe("NftsList tests", () => {
 
     test("Renders correctly without transactions", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getNfts").mockReturnValue(SuccessApiCall([]));
         const screen = render(<NftsList />);
         await waitFor(() => expect(screen.getAllByText(translate("nothing_to_show"))));

--- a/test/unit/src/module/token/component/core/TokenList.spec.tsx
+++ b/test/unit/src/module/token/component/core/TokenList.spec.tsx
@@ -9,7 +9,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("Renders the token list properly", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -17,14 +17,14 @@ describe("Renders the token list properly", () => {
 
     test("Renders correctly", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getTokensBalance").mockReturnValue([token]);
         const screen = render(<TokensList />);
         await waitFor(() => expect(screen.getAllByText("Wrapped BTC")));
     });
     test("Renders empty token list", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getTokensBalance").mockReturnValue([]);
         const screen = render(<TokensList />);
         await waitFor(() => expect(screen.getAllByText(translate("nothing_to_show"))));

--- a/test/unit/src/module/transaction/component/core/SendModal/SendModal.spec.tsx
+++ b/test/unit/src/module/transaction/component/core/SendModal/SendModal.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("SendModal tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterAll(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("SendModal tests", () => {
 
     beforeAll(() => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
             totalBalance: 120000000,
             occupiedBalance: 20000000,

--- a/test/unit/src/module/transaction/component/core/TransactionsList/TransactionsList.spec.tsx
+++ b/test/unit/src/module/transaction/component/core/TransactionsList/TransactionsList.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("TransactionsList tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("TransactionsList tests", () => {
 
     test("Renders correctly with an account", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getTransactions").mockReturnValue(transactions);
 
         const screen = render(<TransactionsList />);
@@ -28,7 +28,7 @@ describe("TransactionsList tests", () => {
     });
     test("Renders correctly without transactions", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getTransactions").mockReturnValue([]);
         const screen = render(<TransactionsList />);
         await waitFor(() => expect(screen.getAllByText(translate("nothing_to_show"))));

--- a/test/unit/src/module/transaction/component/display/ReceiveCard/ReceiveCard.spec.tsx
+++ b/test/unit/src/module/transaction/component/display/ReceiveCard/ReceiveCard.spec.tsx
@@ -14,11 +14,11 @@ import { MnemonicMocked } from "mocks/MnemonicMocked";
 const ADDRESS_MOCK = "0xMockedAddress";
 
 describe("Test for the receive Card", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     beforeEach(() => {
         jest.spyOn(UseSelectedWallet, "default").mockReturnValue(wallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getAddress").mockReturnValue(ADDRESS_MOCK);
     });
 

--- a/test/unit/src/module/transaction/screen/SendConfirmationScreen.spec.tsx
+++ b/test/unit/src/module/transaction/screen/SendConfirmationScreen.spec.tsx
@@ -10,7 +10,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("SendConfirmationScreen tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("SendConfirmationScreen tests", () => {
 
     test("Renders correctly", () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getAddress").mockReturnValue("0xMockedAddress");
         jest.spyOn(Recoil, "useRecoilValue").mockReturnValue({
             amount: 1000,

--- a/test/unit/src/module/transaction/screen/SendSetAmountScreen.spec.tsx
+++ b/test/unit/src/module/transaction/screen/SendSetAmountScreen.spec.tsx
@@ -13,13 +13,13 @@ import { MnemonicMocked } from "mocks/MnemonicMocked";
 import { MINIMUM_DAO_DEPOSIT } from "@env";
 import { FeeRate } from "ckb-peersyst-sdk";
 describe("SendAmountAndMessageScreen tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
     const setSendState = jest.fn();
     beforeAll(() => {
         jest.spyOn(Recoil, "useRecoilState").mockReturnValue([{}, setSendState]);
         jest.spyOn(Recoil, "useRecoilValue").mockReturnValue({ fee: FeeRate.NORMAL });
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
             totalBalance: 12000,
             occupiedBalance: 2000,

--- a/test/unit/src/module/wallet/component/core/WalletBackupAdvise/WalletBackupAdvise.spec.tsx
+++ b/test/unit/src/module/wallet/component/core/WalletBackupAdvise/WalletBackupAdvise.spec.tsx
@@ -9,7 +9,7 @@ import { CKBSDKService } from "module/common/service/CkbSdkService";
 import { serviceInstancesMap } from "module/wallet/state/WalletState";
 
 describe("WalletBackupAdvise", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -18,7 +18,7 @@ describe("WalletBackupAdvise", () => {
         jest.useFakeTimers();
         const handleSelection = jest.fn();
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
             totalBalance: 1,
             occupiedBalance: 0,

--- a/test/unit/src/module/wallet/component/core/WalletCard/WalletCard.spec.tsx
+++ b/test/unit/src/module/wallet/component/core/WalletCard/WalletCard.spec.tsx
@@ -13,7 +13,7 @@ import * as Recoil from "recoil";
 import * as ExpoHapits from "expo-haptics";
 
 describe("WalletCard tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -21,7 +21,7 @@ describe("WalletCard tests", () => {
 
     beforeEach(() => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
             totalBalance: 20000,
             occupiedBalance: 9600,
@@ -47,7 +47,7 @@ describe("WalletCard tests", () => {
         expect(screen.getByText(translate("receive"))).toBeDefined();
     });
 
-    test("Change the currency when the user clics on the balance", async () => {
+    test("Change the currency when the user clicks on the balance", async () => {
         jest.spyOn(Recoil, "useRecoilValue").mockReturnValue({ fiat: "eur" });
         jest.spyOn(useCkbConversion, "default").mockReturnValue({ value: 10, convertBalance: jest.fn() });
         const mockedVibrate = jest.fn();

--- a/test/unit/src/module/wallet/component/core/WalletCard/WalletCardHeader.spec.tsx
+++ b/test/unit/src/module/wallet/component/core/WalletCard/WalletCardHeader.spec.tsx
@@ -8,11 +8,11 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("WalletCardHeader tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     beforeAll(() => {
         jest.spyOn(UseWallet, "default").mockReturnValue(wallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getAddress").mockReturnValue("0xMockedAddress");
     });
 

--- a/test/unit/src/module/wallet/component/input/WalletSelector/WalletSelector.spec.tsx
+++ b/test/unit/src/module/wallet/component/input/WalletSelector/WalletSelector.spec.tsx
@@ -8,7 +8,7 @@ import { serviceInstancesMap } from "module/wallet/state/WalletState";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("WalletSelector tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -16,7 +16,7 @@ describe("WalletSelector tests", () => {
 
     test("Renders correctly", async () => {
         jest.spyOn(UseWalletState, "default").mockReturnValue(mockedUseWallet);
-        jest.spyOn(serviceInstancesMap, "get").mockReturnValue(sdkInstance);
+        jest.spyOn(serviceInstancesMap, "get").mockReturnValue({ testnet: sdkInstance, mainnet: sdkInstance });
         jest.spyOn(sdkInstance, "getCKBBalance").mockReturnValue({
             totalBalance: 1,
             occupiedBalance: 0,

--- a/test/unit/src/module/wallet/screen/CreateWalletSuccessScreen.spec.tsx
+++ b/test/unit/src/module/wallet/screen/CreateWalletSuccessScreen.spec.tsx
@@ -12,7 +12,7 @@ import synchronizeMock from "mocks/synchronize";
 import { MnemonicMocked } from "mocks/MnemonicMocked";
 
 describe("CreateWalletSuccessScreen tests", () => {
-    const sdkInstance = new CKBSDKService(MnemonicMocked);
+    const sdkInstance = new CKBSDKService("testnet", MnemonicMocked);
 
     afterAll(() => {
         jest.restoreAllMocks();


### PR DESCRIPTION
Add mainnet and testnet support.

- Storage now stores mainnet and testnet state and uncommitted transactions
- Settings Network selector can be enabled and disabled with ENABLE_MAINET env variable
- servicaInstanceMap now has a map of service instances, mainnet and testnet