### PR TITLE
[TA-2759]: Add option to send all non blocked funds

### DIFF
--- a/src/module/common/service/CkbSdkService.ts
+++ b/src/module/common/service/CkbSdkService.ts
@@ -133,7 +133,13 @@ export class CKBSDKService {
     }
 
     async sendTransaction(params: SendTransactionParams): Promise<string> {
-        return this.wallet.sendTransaction(BigInt(params.amount), params.mnemonic.join(" "), params.to, params.feeRate);
+        return this.wallet.sendTransaction(
+            BigInt(params.amount),
+            params.mnemonic.join(" "),
+            params.to,
+            params.sendAllFunds,
+            params.feeRate,
+        );
     }
 
     async sendToken(params: TransferTokensParams): Promise<string> {

--- a/src/module/common/service/CkbSdkService.types.ts
+++ b/src/module/common/service/CkbSdkService.types.ts
@@ -15,6 +15,7 @@ export interface SendTransactionParams {
     mnemonic: string[];
     message?: string;
     to: string;
+    sendAllFunds?: boolean;
     feeRate?: FeeRate;
 }
 

--- a/src/module/sdk/core/wallet.service.ts
+++ b/src/module/sdk/core/wallet.service.ts
@@ -376,12 +376,18 @@ export class WalletService {
         return this.ckbService.transfer(address, to, amount, privateKey, feeRate);
     }
 
-    async sendTransaction(amount: bigint, mnemo: string, to: string, feeRate: FeeRate = FeeRate.NORMAL): Promise<string> {
+    async sendTransaction(
+        amount: bigint,
+        mnemo: string,
+        to: string,
+        sendAllFunds = false,
+        feeRate: FeeRate = FeeRate.NORMAL,
+    ): Promise<string> {
         await this.synchronize();
         const addresses = this.getAllAddresses();
         const privateKeys = this.getAllPrivateKeys(mnemo);
 
-        return this.ckbService.transferFromCells(this.getCells(), addresses, to, amount, privateKeys, feeRate);
+        return this.ckbService.transferFromCells(this.getCells(), addresses, to, amount, privateKeys, sendAllFunds, feeRate);
     }
 
     async getCKBBalanceFromAccount(accountId = 0, addressType: AddressType = AddressType.Receiving): Promise<CKBBalance> {


### PR DESCRIPTION
# Add option to send all non blocked funds PR


## Issues

- [Add option to send all non blocked funds](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=fec33287ab9d4308b1685418611bd19c&pm=s)

## Changes

- Add boolean in send to send all funds
- Adapt ckb service to create output from all funds and pay fee from the output
