### PR TITLE
Hotfixes/UI

### DIFF
--- a/src/config/ConfigProvider.tsx
+++ b/src/config/ConfigProvider.tsx
@@ -12,7 +12,11 @@ export interface ConfigProviderProps {
 const ConfigProvider = ({ children }: ConfigProviderProps): JSX.Element => {
     const translate = useTranslate("error");
     const { locale = "en" } = useRecoilValue(settingsState);
-    return <GenesysConfigProvider config={{ ...config, translate, locale }}>{children}</GenesysConfigProvider>;
+    return (
+        <GenesysConfigProvider config={{ ...config, translate, locale }} storeTheme>
+            {children}
+        </GenesysConfigProvider>
+    );
 };
 
 export default ConfigProvider;

--- a/src/locale/locales/el/errors.json
+++ b/src/locale/locales/el/errors.json
@@ -33,5 +33,7 @@
     "transaction_request_already_signed": "Το αίτημα συναλλαγής έχει ήδη υπογραφεί",
     "transaction_request_already_declined": "Το αίτημα συναλλαγής έχει ήδη απορριφθεί",
     "invalid_transaction": "Μη έγκυρη συναλλαγή",
-    "invalid_domain": "Μη έγκυρο domain"
+    "invalid_domain": "Μη έγκυρο domain",
+    "minimun_amount_61_ckb": "Η ελάχιστη τιμή μεταφοράς (κυττάρου) είναι 61 CKB",
+    "insufficient_capacity_for_change_cell": "Ανεπαρκής χωρητικότητα για το κύτταρο αλλαγής"
 }

--- a/src/locale/locales/en/errors.json
+++ b/src/locale/locales/en/errors.json
@@ -35,5 +35,5 @@
     "invalid_transaction": "Invalid transaction",
     "invalid_domain": "Invalid domain",
     "minimun_amount_61_ckb": "Minimum transfer (cell) value is 61 CKB",
-    "insufficient_capacity_for_change_cell" : "Insufficient capacity for change cell"
+    "insufficient_capacity_for_change_cell": "Insufficient capacity for change cell"
 }

--- a/src/locale/locales/en/errors.json
+++ b/src/locale/locales/en/errors.json
@@ -33,5 +33,7 @@
     "transaction_request_already_signed": "Transaction request already signed",
     "transaction_request_already_declined": "Transaction request already declined",
     "invalid_transaction": "Invalid transaction",
-    "invalid_domain": "Invalid domain"
+    "invalid_domain": "Invalid domain",
+    "minimun_amount_61_ckb": "Minimum transfer (cell) value is 61 CKB",
+    "insufficient_capacity_for_change_cell" : "Insufficient capacity for change cell"
 }

--- a/src/locale/locales/es/errors.json
+++ b/src/locale/locales/es/errors.json
@@ -33,5 +33,7 @@
     "transaction_request_already_signed": "Petición de transacción ya firmada",
     "transaction_request_already_declined": "Petición de transacción ya rechazada",
     "invalid_transaction": "Transacción inválida",
-    "invalid_domain": "Dominio inválido"
+    "invalid_domain": "Dominio inválido",
+    "minimun_amount_61_ckb": "El valor mínimo de transferencia (célula) es 61 CKB",
+    "insufficient_capacity_for_change_cell": "Capacidad insuficiente para la célula de cambio"
 }

--- a/src/locale/locales/fr/errors.json
+++ b/src/locale/locales/fr/errors.json
@@ -33,5 +33,7 @@
     "transaction_request_already_signed": "Demande de transaction déjà signée",
     "transaction_request_already_declined": "Demande de transaction déjà refusée",
     "invalid_transaction": "Transaction invalide",
-    "invalid_domain": "Domaine invalide"
+    "invalid_domain": "Domaine invalide",
+    "minimun_amount_61_ckb": "La valeur minimale de transfert (cellule) est de 61 CKB",
+    "insufficient_capacity_for_change_cell": "Capacité insuffisante pour la cellule de changement"
 }

--- a/src/locale/locales/pt/errors.json
+++ b/src/locale/locales/pt/errors.json
@@ -33,5 +33,7 @@
     "transaction_request_already_signed": "Pedido de transação já assinado",
     "transaction_request_already_declined": "Pedido de transação já recusado",
     "invalid_transaction": "Transação inválida",
-    "invalid_domain": "Dominio inválido"
+    "invalid_domain": "Dominio inválido",
+    "minimun_amount_61_ckb": "O valor mínimo de transferência (célula) é 61 CKB",
+    "insufficient_capacity_for_change_cell": "Capacidade insuficiente para a célula de troca"
 }

--- a/src/locale/locales/zh/errors.json
+++ b/src/locale/locales/zh/errors.json
@@ -33,5 +33,7 @@
     "transaction_request_already_signed": "交易请求已签署",
     "transaction_request_already_declined": "交易请求已被拒绝",
     "invalid_transaction": "无效交易",
-    "invalid_domain": "无效域名"
+    "invalid_domain": "无效域名",
+    "minimun_amount_61_ckb": "最小转账（单元）金额为 61 CKB",
+    "insufficient_capacity_for_change_cell": "找零单元容量不足"
 }

--- a/src/module/common/component/display/EmptyListComponent/EmptyListComponent.tsx
+++ b/src/module/common/component/display/EmptyListComponent/EmptyListComponent.tsx
@@ -8,7 +8,7 @@ const EmptyListComponent = ({ title, text }: EmptyListComponentProps): JSX.Eleme
     const translate = useTranslate("error");
     return (
         <Col alignItems="center" style={{ paddingTop: "10%", paddingHorizontal: "5%" }}>
-            <Advise gap={0} title={title || translate("nothing_to_show")} text={text} />
+            <Advise gap={8} title={title || translate("nothing_to_show")} text={text} />
         </Col>
     );
 };

--- a/src/module/common/component/feedback/LoadingModal/LoadingModal.styles.ts
+++ b/src/module/common/component/feedback/LoadingModal/LoadingModal.styles.ts
@@ -36,7 +36,7 @@ export const Gradient = styled(LinearGradient)(() => ({
 }));
 
 export const LoadingModalButton = styled(Button, { variant: "secondary" })(({ theme, safeAreaInsets, dimensions }) => ({
-    color: theme.palette.white,
+    color: theme.palette.primary,
     position: "absolute",
     width: dimensions.width - 40,
     marginLeft: 20,

--- a/src/module/common/component/input/ActionIconButton/ActionIconButton.tsx
+++ b/src/module/common/component/input/ActionIconButton/ActionIconButton.tsx
@@ -1,17 +1,6 @@
-import { useTheme } from "@peersyst/react-native-components";
 import LabeledIconButton from "../LabeledIconButton/LabeledIconButton";
 import { ActionIconButtonProps } from "./ActionIconButton.types";
 
 export default function ActionIconButton({ isActive, action, ...rest }: ActionIconButtonProps): JSX.Element {
-    const {
-        palette: { gray, overlay },
-    } = useTheme();
-    return (
-        <LabeledIconButton
-            labelColor={isActive ? gray[0] : overlay[100]["48%"]}
-            variant={isActive ? "secondary" : "outlined"}
-            onPress={action}
-            {...rest}
-        />
-    );
+    return <LabeledIconButton variant={isActive ? "secondary" : "outlined"} onPress={action} {...rest} />;
 }

--- a/src/module/common/component/input/LabeledIconButton/LabeledIconButton.tsx
+++ b/src/module/common/component/input/LabeledIconButton/LabeledIconButton.tsx
@@ -3,14 +3,14 @@ import IconButton from "../IconButton/IconButton";
 import { TouchableWithoutFeedback, View } from "react-native";
 import { LabeledIconButtonProps } from "./LabeledIconButton.types";
 
-export default function LabeledIconButton({ label, labelColor, onPress, ...iconButtonProps }: LabeledIconButtonProps): JSX.Element {
+export default function LabeledIconButton({ label, onPress, ...iconButtonProps }: LabeledIconButtonProps): JSX.Element {
     return (
         <TouchableWithoutFeedback onPress={onPress}>
-            <Col alignItems="center">
+            <Col alignItems="center" gap={3}>
                 <View style={{ marginHorizontal: "auto" }}>
                     <IconButton onPress={onPress} {...iconButtonProps} />
                 </View>
-                <Typography variant="body4Regular" color={labelColor} adjustsFontSizeToFit>
+                <Typography variant="body4Regular" adjustsFontSizeToFit>
                     {label}
                 </Typography>
             </Col>

--- a/src/module/sdk/core/assets/ckb.service.ts
+++ b/src/module/sdk/core/assets/ckb.service.ts
@@ -23,7 +23,7 @@ export class CKBService {
 
     async transfer(from: string, to: string, amount: bigint, privateKey: string, feeRate: FeeRate = FeeRate.NORMAL): Promise<string> {
         if (amount < this.transferCellSize) {
-            throw new Error("Minimum transfer (cell) value is 61 CKB");
+            throw "minimun_amount_61_ckb";
         }
 
         let txSkeleton = TransactionSkeleton({ cellProvider: this.connection.getEmptyCellProvider() });
@@ -42,7 +42,7 @@ export class CKBService {
         feeRate: FeeRate = FeeRate.NORMAL,
     ): Promise<string> {
         if (amount < this.transferCellSize) {
-            throw new Error("Minimum transfer (cell) value is 61 CKB");
+            throw "minimun_amount_61_ckb";
         }
 
         let txSkeleton = TransactionSkeleton({ cellProvider: this.connection.getEmptyCellProvider() });

--- a/src/module/sdk/core/assets/ckb.service.ts
+++ b/src/module/sdk/core/assets/ckb.service.ts
@@ -23,7 +23,7 @@ export class CKBService {
 
     async transfer(from: string, to: string, amount: bigint, privateKey: string, feeRate: FeeRate = FeeRate.NORMAL): Promise<string> {
         if (amount < this.transferCellSize) {
-            throw "minimun_amount_61_ckb";
+            throw new Error("minimun_amount_61_ckb");
         }
 
         let txSkeleton = TransactionSkeleton({ cellProvider: this.connection.getEmptyCellProvider() });
@@ -42,7 +42,7 @@ export class CKBService {
         feeRate: FeeRate = FeeRate.NORMAL,
     ): Promise<string> {
         if (amount < this.transferCellSize) {
-            throw "minimun_amount_61_ckb";
+            throw new Error("minimun_amount_61_ckb");
         }
 
         let txSkeleton = TransactionSkeleton({ cellProvider: this.connection.getEmptyCellProvider() });

--- a/src/module/sdk/core/transaction.service.ts
+++ b/src/module/sdk/core/transaction.service.ts
@@ -499,7 +499,7 @@ export class TransactionService {
             throw new Error("Insufficient capacity");
         }
         if (changeAmount > 0 && changeCapacity < helpers.minimalCellCapacityCompatible(changeCell).toBigInt()) {
-            throw "insufficient_capacity_for_change_cell";
+            throw new Error("insufficient_capacity_for_change_cell");
         }
 
         if (changeCapacity > BigInt(0)) {

--- a/src/module/sdk/core/transaction.service.ts
+++ b/src/module/sdk/core/transaction.service.ts
@@ -499,7 +499,7 @@ export class TransactionService {
             throw new Error("Insufficient capacity");
         }
         if (changeAmount > 0 && changeCapacity < helpers.minimalCellCapacityCompatible(changeCell).toBigInt()) {
-            throw new Error("Insufficient capacity for change cell");
+            throw "insufficient_capacity_for_change_cell";
         }
 
         if (changeCapacity > BigInt(0)) {

--- a/src/module/settings/components/core/DeleteData/DeleteData.tsx
+++ b/src/module/settings/components/core/DeleteData/DeleteData.tsx
@@ -14,7 +14,7 @@ const DeleteData = () => {
     const { setState: setWalletState, reset: resetWalletState } = useWalletState();
     const queryClient = useQueryClient();
     const { showModal } = useModal();
-    const { showCancelableDialog } = useCancelableDialog();
+    const { showCancelableDialog, hideDialog } = useCancelableDialog();
 
     const handleDelete = () => {
         showModal(ConfirmPinModal, {
@@ -25,6 +25,7 @@ const DeleteData = () => {
                 await SettingsStorage.clear();
                 await queryClient.invalidateQueries();
                 resetWalletState();
+                hideDialog();
             },
         });
     };

--- a/src/module/settings/components/core/DeleteOneWallet/DeleteOneWallet.tsx
+++ b/src/module/settings/components/core/DeleteOneWallet/DeleteOneWallet.tsx
@@ -14,7 +14,7 @@ import useCancelableDialog from "module/common/hook/useCancelableDialog";
 
 const DeleteOneWallet = () => {
     const translate = useTranslate();
-    const { showCancelableDialog } = useCancelableDialog();
+    const { showCancelableDialog, hideDialog } = useCancelableDialog();
     const { showModal } = useModal();
     const {
         reset,
@@ -66,6 +66,7 @@ const DeleteOneWallet = () => {
                         serviceInstancesMap.delete(serviceInstancesSize);
                         removeWalletQueries(lastServiceInstanceIndex);
                     }
+                    hideDialog();
                 },
             });
         }

--- a/src/module/wallet/screen/EnterWalletMnemonicScreen.tsx
+++ b/src/module/wallet/screen/EnterWalletMnemonicScreen.tsx
@@ -18,7 +18,7 @@ export interface EnterWalletMnemonicScreenProps {
 
 const EnterWalletMnemonicScreen = ({ onSubmit, submitText }: EnterWalletMnemonicScreenProps): JSX.Element => {
     const translateError = useTranslate("error");
-    const { setMnemonic } = useCreateWallet();
+    const { state, setMnemonic } = useCreateWallet();
     const [submitted, setSubmitted] = useState(false);
     const { showToast } = useToast();
 
@@ -47,7 +47,7 @@ const EnterWalletMnemonicScreen = ({ onSubmit, submitText }: EnterWalletMnemonic
             <Form onSubmit={handleSubmit}>
                 <Col gap={24} style={{ marginTop: 5 }}>
                     <MnemonicInput />
-                    <Button type="submit" fullWidth>
+                    <Button type="submit" fullWidth disabled={!!state.mnemonic}>
                         {submitText}
                     </Button>
                 </Col>

--- a/src/query/handleErrorMessage.ts
+++ b/src/query/handleErrorMessage.ts
@@ -14,7 +14,12 @@ export function handleErrorMessage(error: ApiError | any, translate: typeof i18n
     const message = error.body?.message || error.statusText;
 
     if (error && !code && !message) {
-        return { message: translate(error in en.error ? error : "somethingWentWrong", { ns: "error" }), type: "error" };
+        return {
+            message: translate(error instanceof Error ? [error.message as any, "somethingWnetWrong"] : "somethingWentWrong", {
+                ns: "error",
+            }),
+            type: "error",
+        };
     } else if (!code || code === 500) return { message: translate("somethingWentWrong", { ns: "error" }), type: "error" };
     else if (code === 401) return { message: translate("sessionExpired", { ns: "error" }), type: "warning" };
     else return { message: translate(message in en.error ? error.body.message : "somethingWentWrong", { ns: "error" }), type: "error" };

--- a/src/query/handleErrorMessage.ts
+++ b/src/query/handleErrorMessage.ts
@@ -12,7 +12,10 @@ export type UseHandleErrorMessage = (error: ApiError | any) => HandleApiErrorMes
 export function handleErrorMessage(error: ApiError | any, translate: typeof i18n.t): HandleApiErrorMessageResult {
     const code = error.body?.statusCode || error.status;
     const message = error.body?.message || error.statusText;
-    if (!code || code === 500) return { message: translate("somethingWentWrong", { ns: "error" }), type: "error" };
+
+    if (error && !code && !message) {
+        return { message: translate(error in en.error ? error : "somethingWentWrong", { ns: "error" }), type: "error" };
+    } else if (!code || code === 500) return { message: translate("somethingWentWrong", { ns: "error" }), type: "error" };
     else if (code === 401) return { message: translate("sessionExpired", { ns: "error" }), type: "warning" };
     else return { message: translate(message in en.error ? error.body.message : "somethingWentWrong", { ns: "error" }), type: "error" };
 }


### PR DESCRIPTION
# Hotfixes/UI

## Issues

closes #

## Dependencies

#

## Changes : Resolved

- After introducing mnemonic to import, Import wallet button should only be clickable once. If not it imports the same account multiple times.
- At Security settings, delete wallet. After authorising delete, are you sure? modal doesn’t close.
- After delete data, are you sure? modal doesn’t close.
- At Succesful transaction screen. Confirm text doesn’t show up.
- Change theme switch doesn’t respond and won’t change theme.
- En la wallet card, al texto de los botones les falta un poco de espacio y el texto sale negro, debería ser blanco
- Al "No hay NFTs" le falta espacio
